### PR TITLE
Docker-Image based on Maven 3.8.1 and OpenJDK 16

### DIFF
--- a/.github/workflows/buildandpush-maven-openjdk-16.yml
+++ b/.github/workflows/buildandpush-maven-openjdk-16.yml
@@ -1,14 +1,14 @@
-name: Build and Push (Maven / OpenJDK 15)
+name: Build and Push (Maven / OpenJDK 16)
 
 on:
   push:
     branches: [ main ]
     paths: 
-      - dockerfiles/maven-openjdk-15/dockerfile
+      - dockerfiles/maven-openjdk-16/dockerfile
   pull_request:
     branches: [ main ]
     paths: 
-      - dockerfiles/maven-openjdk-15/dockerfile
+      - dockerfiles/maven-openjdk-16/dockerfile
   schedule:
     - cron: '0 0 * * *'  # every day at midnight 
 
@@ -33,7 +33,8 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        file: ./dockerfiles/maven-openjdk-15/dockerfile
+        file: ./dockerfiles/maven-openjdk-16/dockerfile
         push: true
         tags: |
-          daniiiol/dependency-check-maven-prepared:openjdk-15
+          daniiiol/dependency-check-maven-prepared:latest
+          daniiiol/dependency-check-maven-prepared:openjdk-16

--- a/dockerfiles/maven-openjdk-16/dockerfile
+++ b/dockerfiles/maven-openjdk-16/dockerfile
@@ -1,0 +1,9 @@
+FROM maven:3.8.1-openjdk-16
+
+COPY ./warmup/pom.xml /warmup/pom.xml
+
+RUN mvn -f /warmup/pom.xml -Dmaven.main.skip org.owasp:dependency-check-maven:check
+RUN rm -R /warmup/
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]


### PR DESCRIPTION
Hoi Dani  :-)

Habe mal die Konfigs für Maven 3.8.1 und OpenJDK 16 vorbereitet.

Bin allerdings Github unerfahren und habe hier nicht versucht, die Build-Pipeline zum laufen zu kriegen. Wusste nicht, ob dann direkt was auf Dockerhub gepushed würde ;).

Grüsse
David
/Juris